### PR TITLE
fix(auth): stop 500 on every flash() call by repointing template paths

### DIFF
--- a/blueprints/frontend.py
+++ b/blueprints/frontend.py
@@ -152,7 +152,7 @@ def login_required(func):
     @wraps(func)
     async def wrapper(*args, **kwargs):
         if not session or 'authenticated' not in session:
-            return await flash('error', 'You must be logged in to access that page.', 'hinaDir/login')
+            return await flash('error', 'You must be logged in to access that page.', 'login')
         return await func(*args, **kwargs)
     return wrapper
 
@@ -378,7 +378,7 @@ async def settings_profile_post():
     if new_name != old_name or new_email != old_email:
         session.pop('authenticated', None)
         session.pop('user_data', None)
-        return await flash('success', 'Your username/email have been changed! Please login again.', 'hinaDir/login')
+        return await flash('success', 'Your username/email have been changed! Please login again.', 'login')
 
     # Hue-only change: update session and stay on page
     if new_hue is not None and 0 <= new_hue <= 360:
@@ -598,7 +598,7 @@ async def settings_password_post():
 
     user_row = await glob.db.fetch('SELECT pw_bcrypt FROM users WHERE id = %s', [session['user_data']['id']])
     if not user_row:
-        return await flash('error', 'User not found.', 'hinaDir/login')
+        return await flash('error', 'User not found.', 'login')
 
     pw_bcrypt = user_row['pw_bcrypt'].encode()  # ty:ignore[invalid-argument-type]
     pw_md5 = hashlib.md5(old_password.encode()).hexdigest().encode()  # ty:ignore[unresolved-attribute]
@@ -632,7 +632,7 @@ async def settings_password_post():
 
     session.pop('authenticated', None)
     session.pop('user_data', None)
-    return await flash('success', 'Your password has been changed! Please log in again.', 'hinaDir/login')
+    return await flash('success', 'Your password has been changed! Please log in again.', 'login')
 
 @frontend.route('/u/<id>')
 @frontend.route('/user/<id>')
@@ -760,7 +760,7 @@ async def login_post():
     if not user_info or user_info['id'] == 1:  # ty:ignore[invalid-argument-type]
         if glob.config.debug:
             klogging.log(f"{username}'s login failed - account doesn't exist.", klogging.Ansi.LYELLOW)
-        return await flash('error', 'Account does not exist.', 'hinaDir/login')
+        return await flash('error', 'Account does not exist.', 'login')
 
     bcrypt_cache = glob.cache['bcrypt']
     pw_bcrypt = user_info['pw_bcrypt'].encode()  # ty:ignore[invalid-argument-type]
@@ -770,12 +770,12 @@ async def login_post():
         if pw_md5 != bcrypt_cache[pw_bcrypt]:
             if glob.config.debug:
                 klogging.log(f"{username}'s login failed - pw incorrect.", klogging.Ansi.LYELLOW)
-            return await flash('error', 'Password is incorrect.', 'hinaDir/login')
+            return await flash('error', 'Password is incorrect.', 'login')
     else:
         if not bcrypt.checkpw(pw_md5, pw_bcrypt):
             if glob.config.debug:
                 klogging.log(f"{username}'s login failed - pw incorrect.", klogging.Ansi.LYELLOW)
-            return await flash('error', 'Password is incorrect.', 'hinaDir/login')
+            return await flash('error', 'Password is incorrect.', 'login')
         bcrypt_cache[pw_bcrypt] = pw_md5
 
     if not user_info['priv'] & Privileges.Verified:  # ty:ignore[invalid-argument-type]
@@ -786,7 +786,7 @@ async def login_post():
     if not user_info['priv'] & Privileges.Normal:  # ty:ignore[invalid-argument-type]
         if glob.config.debug:
             klogging.log(f"{username}'s login failed - banned.", klogging.Ansi.RED)
-        return await flash('error', 'Your account is restricted. You are not allowed to log in.', 'hinaDir/login')
+        return await flash('error', 'Your account is restricted. You are not allowed to log in.', 'login')
 
     if glob.config.debug:
         klogging.log(f"{username}'s login succeeded.", klogging.Ansi.LGREEN)
@@ -834,11 +834,11 @@ async def register():
         return await flash('error', 'Registrations are currently disabled.', 'home')
 
     if g.isDevEnv:
-        return await render_template('hinaDir/register.html', globalNotice=g.globalNotice, flash=f"This Website is the Dev Environment. Please play on <a href='https://{glob.config.official_domain}'>our Official Server</a>", status="success")
+        return await render_template('register.html', globalNotice=g.globalNotice, flash=f"This Website is the Dev Environment. Please play on <a href='https://{glob.config.official_domain}'>our Official Server</a>", status="success")
     if g.maintenance:
-        return await render_template('hinaDir/register.html', globalNotice=g.globalNotice, flash="Website is currently under maintenance", status="success")
+        return await render_template('register.html', globalNotice=g.globalNotice, flash="Website is currently under maintenance", status="success")
 
-    return await render_template('hinaDir/register.html', globalNotice=g.globalNotice)
+    return await render_template('register.html', globalNotice=g.globalNotice)
 
 @frontend.route('/register', methods=['POST'])
 @error_catcher
@@ -860,34 +860,34 @@ async def register_post():
     if glob.config.hCaptcha_sitekey != 'changeme':
         captcha_data = form.get('h-captcha-response', type=str)
         if not captcha_data or not await utils.validate_captcha(captcha_data):
-            return await flash('error', 'Captcha failed.', 'hinaDir/register')
+            return await flash('error', 'Captcha failed.', 'register')
 
     if not regexes.username.match(username):
-        return await flash('error', 'Invalid username syntax.', 'hinaDir/register')
+        return await flash('error', 'Invalid username syntax.', 'register')
 
     if '_' in username and ' ' in username:
-        return await flash('error', 'Username may contain "_" or " ", but not both.', 'hinaDir/register')
+        return await flash('error', 'Username may contain "_" or " ", but not both.', 'register')
 
     if username in glob.config.disallowed_names:
-        return await flash('error', 'Disallowed username; pick another.', 'hinaDir/register')
+        return await flash('error', 'Disallowed username; pick another.', 'register')
 
     if await glob.db.fetch('SELECT 1 FROM users WHERE name = %s', username):
-        return await flash('error', 'Username already taken by another user.', 'hinaDir/register')
+        return await flash('error', 'Username already taken by another user.', 'register')
 
     if not regexes.email.match(email):
-        return await flash('error', 'Invalid email syntax.', 'hinaDir/register')
+        return await flash('error', 'Invalid email syntax.', 'register')
 
     if await glob.db.fetch('SELECT 1 FROM users WHERE email = %s', email):
-        return await flash('error', 'Email already taken by another user.', 'hinaDir/register')
+        return await flash('error', 'Email already taken by another user.', 'register')
 
     if not 8 <= len(passwd_txt) <= 32:
-        return await flash('error', 'Password must be 8-32 characters in length.', 'hinaDir/register')
+        return await flash('error', 'Password must be 8-32 characters in length.', 'register')
 
     if len(set(passwd_txt)) <= 3:
-        return await flash('error', 'Password must have more than 3 unique characters.', 'hinaDir/register')
+        return await flash('error', 'Password must have more than 3 unique characters.', 'register')
 
     if passwd_txt.lower() in glob.config.disallowed_passwords:
-        return await flash('error', 'That password was deemed too simple.', 'hinaDir/register')
+        return await flash('error', 'That password was deemed too simple.', 'register')
 
     # Hashing
     pw_md5 = hashlib.md5(passwd_txt.encode()).hexdigest().encode()
@@ -928,7 +928,7 @@ async def register_post():
 @error_catcher
 async def logout():
     if 'authenticated' not in session:
-        return await flash('error', "You can't logout if you aren't logged in!", 'hinaDir/login')
+        return await flash('error', "You can't logout if you aren't logged in!", 'login')
 
     if glob.config.debug:
         klogging.log(f'{session["user_data"]["name"]} logged out.', klogging.Ansi.LGREEN)
@@ -936,7 +936,7 @@ async def logout():
     session.pop('authenticated', None)
     session.pop('user_data', None)
 
-    return await flash('success', 'Successfully logged out!', 'hinaDir/login')
+    return await flash('success', 'Successfully logged out!', 'login')
 
 @frontend.route('/changelog')
 @frontend.route('/changelog/<type>/<category>')

--- a/blueprints/hinaDir/beatmaps.py
+++ b/blueprints/hinaDir/beatmaps.py
@@ -112,7 +112,7 @@ def _cheesegull_to_v2(cg: dict) -> dict:
 @hina_beatmaps.route('/beatmaps')
 async def beatmaps_page():
     if not session or 'authenticated' not in session:
-        return await flash('error', 'You must be logged in to access that page.', 'hinaDir/login')
+        return await flash('error', 'You must be logged in to access that page.', 'login')
     return await render_template('beatmaps.html', globalNotice=g.globalNotice)
 
 

--- a/blueprints/hinaDir/friends.py
+++ b/blueprints/hinaDir/friends.py
@@ -15,7 +15,7 @@ def login_required(func):
     async def wrapper(*args, **kwargs):
         if not session or 'authenticated' not in session:
             from objects.utils import flash
-            return await flash('error', 'You must be logged in to access that page.', 'hinaDir/login')
+            return await flash('error', 'You must be logged in to access that page.', 'login')
         return await func(*args, **kwargs)
     return wrapper
 


### PR DESCRIPTION
The auth shell was relocated by upstream commit bf1cd4d

25 call sites updated across:
- blueprints/frontend.py (21 sites — login_required, settings, forgot_password handler, login_post error/success branches, register validation errors, logout flash)
- blueprints/hinaDir/friends.py (1 — login_required wrapper)
- blueprints/hinaDir/beatmaps.py (1 — beatmaps_page guard)
- blueprints/frontend.py (3 render_template calls for register page dev-env/maintenance banners)